### PR TITLE
Add CentOS 7 and 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-FOLDERS := debian-buster ubuntu-18.04 ubuntu-20.04
+FOLDERS := debian-buster ubuntu-18.04 ubuntu-20.04 centos-7 centos-8
 RM	:= rm -f
 
 .PHONY: $(FOLDERS) clean

--- a/ansible/centos.yml
+++ b/ansible/centos.yml
@@ -1,0 +1,21 @@
+- name: Install EPEL
+  package:
+    name: epel-release
+- name: Add IntelMQ repository
+  yum_repository:
+    name: intelmq
+    repo_gpgcheck: yes
+    baseurl: https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_$releasever/
+    gpgkey: "https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
+    description: IntelMQ Repository
+- name: Set webserver service name
+  set_fact:
+    webserver: httpd
+# for some weird reason, CentOS 7 can't resolve the dependency /bin/python3.6 with python36 not installed
+- name: install python36 on CentOS 7
+  package:
+    name: python36
+  when: ansible_facts['distribution'] == "CentOS" and ansible_distribution_major_version == "7"
+# Also possible with the module ansible.posix.selinux, but requires a non-standard galaxy
+- name: Disable SELinux
+  command: setenforce 0

--- a/ansible/centos_postinstall.yml
+++ b/ansible/centos_postinstall.yml
@@ -1,0 +1,10 @@
+- name: Configure API user
+  command:
+    cmd: hug -m intelmq_api.serve -c add_user admin --password=asdf
+  environment:
+    INTELMQ_API_CONFIG: /etc/intelmq/api-config.json
+  become: yes
+  become_user: apache
+  vars:
+    # required because of become_user with an unprivileged user. see https://docs.ansible.com/ansible/latest/user_guide/become.html#id6
+    ansible_ssh_pipelining: yes

--- a/ansible/debian_based.yml
+++ b/ansible/debian_based.yml
@@ -1,3 +1,8 @@
+- name: Install gpg
+  apt:
+    update-cache: yes
+    pkg:
+      - gpg
 - name: Set user for IntelMQ API
   debconf:
     name: python3-intelmq-api
@@ -16,3 +21,9 @@
     question: intelmq-api/password-repeat
     value: asdf
     vtype: password
+- name: Set webserver service name
+  set_fact:
+    webserver: apache2
+- name: Install apache2 webserver
+  package:
+    name: apache2

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,11 +1,6 @@
 - hosts: all
   become: yes
   tasks:
-    - name: Install packages
-      apt:
-        update-cache: yes
-        pkg:
-          - gpg
     - name: Prepare Debian and Ubuntu
       include: debian_based.yml
       when: ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "Ubuntu"
@@ -18,13 +13,23 @@
     - name: Setup Ubuntu 20.04
       include: ubuntu_2004.yml
       when: ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_version'] == "20.04"
-    - name: Install packages
+    - name: Update APT cache
       apt:
         update-cache: yes
-        pkg:
-          - python3-intelmq-api
-          - intelmq-manager
-          - apache2
+      when: ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "Ubuntu"
+    - name: Setup CentOS
+      include: centos.yml
+      when: ansible_facts['distribution'] == "CentOS"
+    - name: Install IntelMQ packages
+      package:
+        name: "{{ item }}"
+      with_items:
+      - intelmq-manager
+      - intelmq-api
+      - intelmq
+    - name: Setup CentOS
+      include: centos_postinstall.yml
+      when: ansible_facts['distribution'] == "CentOS"
     - name: Copy runtime.conf
       copy:
         src: '../assets/runtime.conf'
@@ -33,6 +38,15 @@
       copy:
         src: '../assets/pipeline.conf'
         dest: '/etc/intelmq/pipeline.conf'
+    - name: Make sure redis is running
+      ansible.builtin.systemd:
+        state: started
+        name: redis
+    - name: Make sure webserver is running
+      ansible.builtin.systemd:
+        state: started
+        name: "{{webserver}}"
+
 
 
 # CLI related tests

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -53,7 +53,7 @@
 #
 # Those tests run intelmqctl
 #
-    - name: Run Manager tests
+    - name: Run CLI tests
       include: "{{ item }}"
       loop: "{{ query('fileglob', 'tasks/cli/*.yml') | sort }}"
 

--- a/ansible/tasks/cli/01_status.yml
+++ b/ansible/tasks/cli/01_status.yml
@@ -1,5 +1,7 @@
-- command: intelmqctl status file-output
+- name: Run intelmqctl status file-output
+  command: intelmqctl status file-output
   register: intelmqctlstatusfileoutput
   ignore_errors: yes
-- assert:
+- name: Checkout output of command
+  assert:
     that: "'Bot file-output is stopped.' in intelmqctlstatusfileoutput.stdout"

--- a/centos-7/Vagrantfile
+++ b/centos-7/Vagrantfile
@@ -1,0 +1,11 @@
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "centos/7"
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "../ansible/playbook.yml"
+  end
+end
+

--- a/centos-8/Vagrantfile
+++ b/centos-8/Vagrantfile
@@ -1,0 +1,11 @@
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "centos/8"
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "../ansible/playbook.yml"
+  end
+end
+


### PR DESCRIPTION
This adds instructions for CentOS 7 and CentOS 8.

- Set's up the repositories
- disables SELinux, as it is currently not supported by the API
- ensures web server and Redis are running, as these services are not enabled and started by default
- configures the API user

A few changes in the debian-parts were necessary as well, basically moving all Debian-specific instructions to separate files.