### PR TITLE
add option to test stable repos with env variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,12 @@ To run one of the VMs you enter the corresponding directory and run ``vagrant up
 You can enter the VM using ``vagrant ssh``. Every VM exposes port ``80`` on the host port ``8080``.
 You can halt the VM using ``vagrant halt``, you can destroy the VM by using ``vagrant destroy``.
 
-The tests *should* be indepotent, so running ``vagrant provision`` after running ``vagrant up`` should not give another result.
+The tests *should* be idempotent, so running ``vagrant provision`` after running ``vagrant up`` should not give another result.
 
 There is a ``Makefile`` that runs ``vagrant up`` and ``vagrant destroy`` for everyone of the boxes and saves the output to logfiles.
+
+Unstable and stable
+-------------------
+
+By default the repository tests the *unstable* repositories (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq/``).
+Set the environment variable ``intelmq_vagrant_test_stable=yes`` to test the *stable* repositories instead (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/``).

--- a/ansible/centos.yml
+++ b/ansible/centos.yml
@@ -5,8 +5,8 @@
   yum_repository:
     name: intelmq
     repo_gpgcheck: yes
-    baseurl: https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_$releasever/
-    gpgkey: "https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
+    baseurl: "{{ repository_base }}/CentOS_$releasever/"
+    gpgkey: "{{ repository_base }}/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
     description: IntelMQ Repository
 - name: Set webserver service name
   set_fact:

--- a/ansible/debian_10.yml
+++ b/ansible/debian_10.yml
@@ -1,8 +1,8 @@
 - name: Add apt key
   apt_key:
-    url: https://download.opensuse.org/repositories/home:sebix:intelmq:/unstable/Debian_10/Release.key
+    url: "{{ repository_base }}/Debian_10/Release.key"
     state: present
 - name: Setup APT repository Debian 10
   apt_repository:
-    repo: deb http://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/Debian_10/ /
+    repo: "deb {{ repository_base }}/Debian_10/ /"
     state: present

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,6 +1,10 @@
+
 - hosts: all
   become: yes
   tasks:
+    - name: Set repository URL to stable
+      set_fact:
+        repository_base: "{{ 'https://download.opensuse.org/repositories/home:/sebix:/intelmq/' if lookup('env', 'intelmq_vagrant_test_stable') == 'yes' else 'https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/'}}"
     - name: Prepare Debian and Ubuntu
       include: debian_based.yml
       when: ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "Ubuntu"

--- a/ansible/ubuntu_1804.yml
+++ b/ansible/ubuntu_1804.yml
@@ -1,8 +1,8 @@
 - name: Add apt key
   apt_key:
-    url: https://download.opensuse.org/repositories/home:sebix:intelmq:/unstable/xUbuntu_18.04/Release.key
+    url: "{{ repository_base }}/xUbuntu_18.04/Release.key"
     state: present
 - name: Setup APT repository Ubuntu 18.04
   apt_repository:
-    repo: deb http://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/xUbuntu_18.04/ /
+    repo: "deb {{ repository_base }}/xUbuntu_18.04/ /"
     state: present

--- a/ansible/ubuntu_2004.yml
+++ b/ansible/ubuntu_2004.yml
@@ -1,8 +1,8 @@
 - name: Add apt key
   apt_key:
-    url: https://download.opensuse.org/repositories/home:sebix:intelmq:/unstable/xUbuntu_20.04/Release.key
+    url: "{{ repository_base }}/xUbuntu_20.04/Release.key"
     state: present
 - name: Setup APT repository Ubuntu 20.04
   apt_repository:
-    repo: deb http://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/xUbuntu_20.04/ /
+    repo: "deb {{ repository_base }}/xUbuntu_20.04/ /"
     state: present


### PR DESCRIPTION
By default the repository tests the *unstable* repositories (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq/``).
Set the environment variable ``intelmq_vagrant_test_stable=yes`` to test the *stable* repositories instead (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/``).