### PR TITLE
ENH: add inventory file

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,0 +1,3 @@
+all:
+  hosts:
+    localhost


### PR DESCRIPTION
This way we can run the ansible recipies without vagrant, using
ansible-playbook --connection=local -i inventory.yml playbook.yml
