### PR TITLE
Better stable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,3 @@ Run scripts locally
 To run the ansible recipies without vagrant directly on the local machine, use:
 
     ansible-playbook --connection=local -i ansible/inventory.yml ansible/playbook.yml
-
-Unstable and stable
--------------------
-
-By default the repository tests the *unstable* repositories (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq/``).
-Set the environment variable ``intelmq_vagrant_test_stable=yes`` to test the *stable* repositories instead (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/``).

--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,11 @@ Run scripts locally
 To run the ansible recipies without vagrant directly on the local machine, use:
 
     ansible-playbook --connection=local -i ansible/inventory.yml ansible/playbook.yml
+
+stable CentOS repos
+-------------------
+
+By default the repository tests the *unstable* repositories (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq/``).
+Set the environment variable ``intelmq_vagrant_test_stable=yes`` to test the *stable* repositories instead (base ``https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/``).
+
+Only implemented for CentOS.

--- a/ansible/centos.yml
+++ b/ansible/centos.yml
@@ -5,8 +5,8 @@
   yum_repository:
     name: intelmq
     repo_gpgcheck: yes
-    baseurl: "{{ repository_base }}/CentOS_$releasever/"
-    gpgkey: "{{ repository_base }}/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
+    baseurl: https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_$releasever/
+    gpgkey: "https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
     description: IntelMQ Repository
 - name: Set webserver service name
   set_fact:

--- a/ansible/centos.yml
+++ b/ansible/centos.yml
@@ -1,13 +1,22 @@
 - name: Install EPEL
   package:
     name: epel-release
-- name: Add IntelMQ repository
+- name: Add IntelMQ stable repository
   yum_repository:
     name: intelmq
     repo_gpgcheck: yes
+    baseurl: https://download.opensuse.org/repositories/home:/sebix:/intelmq/CentOS_$releasever/
+    gpgkey: "https://download.opensuse.org/repositories/home:/sebix:/intelmq/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
+    description: IntelMQ stable Repository
+- name: Add IntelMQ unstable repository
+  yum_repository:
+    name: intelmq_unstable
+    repo_gpgcheck: yes
     baseurl: https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_$releasever/
     gpgkey: "https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/CentOS_{{ ansible_distribution_major_version }}/repodata/repomd.xml.key"
-    description: IntelMQ Repository
+    description: IntelMQ unstable Repository
+    priority: 90
+  when: lookup('env', 'intelmq_vagrant_test_stable') != 'yes'
 - name: Set webserver service name
   set_fact:
     webserver: httpd

--- a/ansible/debian_10.yml
+++ b/ansible/debian_10.yml
@@ -1,8 +1,8 @@
 - name: Add apt key
   apt_key:
-    url: "{{ repository_base }}/Debian_10/Release.key"
+    url: https://download.opensuse.org/repositories/home:sebix:intelmq:/unstable/Debian_10/Release.key
     state: present
 - name: Setup APT repository Debian 10
   apt_repository:
-    repo: "deb {{ repository_base }}/Debian_10/ /"
+    repo: deb http://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/Debian_10/ /
     state: present

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,10 +1,6 @@
-
 - hosts: all
   become: yes
   tasks:
-    - name: Set repository URL to stable
-      set_fact:
-        repository_base: "{{ 'https://download.opensuse.org/repositories/home:/sebix:/intelmq/' if lookup('env', 'intelmq_vagrant_test_stable') == 'yes' else 'https://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/'}}"
     - name: Prepare Debian and Ubuntu
       include: debian_based.yml
       when: ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "Ubuntu"

--- a/ansible/ubuntu_1804.yml
+++ b/ansible/ubuntu_1804.yml
@@ -1,8 +1,8 @@
 - name: Add apt key
   apt_key:
-    url: "{{ repository_base }}/xUbuntu_18.04/Release.key"
+    url: https://download.opensuse.org/repositories/home:sebix:intelmq:/unstable/xUbuntu_18.04/Release.key
     state: present
 - name: Setup APT repository Ubuntu 18.04
   apt_repository:
-    repo: "deb {{ repository_base }}/xUbuntu_18.04/ /"
+    repo: deb http://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/xUbuntu_18.04/ /
     state: present

--- a/ansible/ubuntu_2004.yml
+++ b/ansible/ubuntu_2004.yml
@@ -1,8 +1,8 @@
 - name: Add apt key
   apt_key:
-    url: "{{ repository_base }}/xUbuntu_20.04/Release.key"
+    url: https://download.opensuse.org/repositories/home:sebix:intelmq:/unstable/xUbuntu_20.04/Release.key
     state: present
 - name: Setup APT repository Ubuntu 20.04
   apt_repository:
-    repo: "deb {{ repository_base }}/xUbuntu_20.04/ /"
+    repo: deb http://download.opensuse.org/repositories/home:/sebix:/intelmq:/unstable/xUbuntu_20.04/ /
     state: present


### PR DESCRIPTION
- Removes the old solution using the repository_base variable, which adds more complexity than it reduces
- changes the logic to always install the base stable repo and the switch controls if the unstable repo should be installed on top of it.
- fixes the centos 8 unstable test fail